### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ book := &Book{}
 coll := mgm.Coll(book)
 
 // Find and decode doc to the book model.
-_ = coll.FindById("5e0518aa8f1a52b0b9410ee3", book)
+_ = coll.FindByID("5e0518aa8f1a52b0b9410ee3", book)
 
 // Get first doc of collection 
 _ = coll.First(bson.M{}, book)


### PR DESCRIPTION
The function is called `FindByID` instead of `FindById`