### PR TITLE
Removed interface{} as a return type for Get/Set/PrepareID

### DIFF
--- a/model.go
+++ b/model.go
@@ -1,5 +1,7 @@
 package mgm
 
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
 // CollectionGetter interface contain method to return
 // model's custom collection.
 type CollectionGetter interface {
@@ -20,9 +22,9 @@ type CollectionNameGetter interface {
 type Model interface {
 	// PrepareID convert id value if need, and then
 	// return it.(e.g convert string to objectId)
-	PrepareID(id interface{}) (interface{}, error)
+	PrepareID(id interface{}) (primitive.ObjectID, error)
 
-	GetID() interface{}
+	GetID() primitive.ObjectID
 	SetID(id interface{})
 }
 

--- a/model.go
+++ b/model.go
@@ -25,7 +25,7 @@ type Model interface {
 	PrepareID(id interface{}) (primitive.ObjectID, error)
 
 	GetID() primitive.ObjectID
-	SetID(id interface{})
+	SetID(id interface{}) error
 }
 
 // DefaultModel struct contain model's default fields.

--- a/model_test.go
+++ b/model_test.go
@@ -20,6 +20,6 @@ func TestPrepareId(t *testing.T) {
 	hexId := "5df7fb2b1fff9ee374b6bd2a"
 	val, err := d.PrepareID(hexId)
 	id, _ := primitive.ObjectIDFromHex(hexId)
-	require.Equal(t, val.(primitive.ObjectID), id)
+	require.Equal(t, val, id)
 	util.AssertErrIsNil(t, err)
 }


### PR DESCRIPTION
The following functions `GetID`, `SetID` and `PrepareID` all know there return type... There is no need to return a `interface{}` as this causes unneeded casting by anyone using the package.

Also cleaned up some of the reflection in those functions above to make them "smarter" using switch on type.

This makes it always assume we can take either a string (gets converted) or a primitive.ObjectID 

