### PR TITLE
Added feature to disconnect the default config client

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -3,10 +3,11 @@ package mgm
 import (
 	"context"
 	"errors"
+	"time"
+
 	"github.com/Kamva/mgm/v3/internal/util"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"time"
 )
 
 var config *Config
@@ -82,6 +83,16 @@ func SetDefaultConfig(conf *Config, dbName string, opts ...*options.ClientOption
 	db = client.Database(dbName)
 
 	return nil
+}
+
+// DisconnectDefaultConfigWithCtx disconnects the default client
+func DisconnectDefaultConfigWithCtx(ctx context.Context) error {
+	return client.Disconnect(ctx)
+}
+
+// DisconnectDefaultConfig disconnects the default client
+func DisconnectDefaultConfig() error {
+	return DisconnectDefaultConfigWithCtx(ctx())
 }
 
 // CollectionByName return new collection from default config

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,12 +1,13 @@
 package mgm_test
 
 import (
+	"testing"
+
 	"github.com/Kamva/mgm/v3"
 	"github.com/Kamva/mgm/v3/internal/util"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
-	"testing"
 )
 
 func TestSetupDefaultConnection(t *testing.T) {
@@ -69,6 +70,16 @@ func TestGetNewClient(t *testing.T) {
 	coll := mgm.NewCollection(client.Database("test_db"), "test_col")
 
 	require.Equal(t, coll.Name(), "test_col", "expected collection with %v name, got %v", "test_col", coll.Name())
+}
+
+func TestDisconnectDefaultConfig(t *testing.T) {
+	setupDefConnection()
+	require.Nil(t, mgm.DisconnectDefaultConfig())
+}
+
+func TestDisconnectDefaultConfigWithCtx(t *testing.T) {
+	setupDefConnection()
+	require.Nil(t, mgm.DisconnectDefaultConfigWithCtx(mgm.Ctx()))
 }
 
 func TestGetDefaultConfigBeforeSettingItUp(t *testing.T) {


### PR DESCRIPTION
Added the possibility to defer disconnecting the default client. Another possibility is to make the client created by the default config accessible using a Getter.