### PR TITLE
Added omitempty struct flag to CreatedAt field.

### DIFF
--- a/field.go
+++ b/field.go
@@ -14,7 +14,7 @@ type IDField struct {
 // DateFields struct contains the `created_at` and `updated_at`
 // fields that autofill when inserting or updating a model.
 type DateFields struct {
-	CreatedAt time.Time `json:"created_at" bson:"created_at"`
+	CreatedAt time.Time `json:"created_at" bson:"created_at,omitempty"`
 	UpdatedAt time.Time `json:"updated_at" bson:"updated_at"`
 }
 
@@ -51,7 +51,7 @@ func (f *DateFields) Creating() error {
 	return nil
 }
 
-// Saving hook is used here to set the `updated_at` field 
+// Saving hook is used here to set the `updated_at` field
 // value when creating or updateing a model.
 // TODO: get context as param the next version(4).
 func (f *DateFields) Saving() error {


### PR DESCRIPTION
Issue: when calling Update() on a collection, null values get written as per JSON/BSON convention, but the update method only handles the UpdatedAt field. As such CreatedAt gets set to `0001-01-01T00:00:00.000+00:00`

Fix: set CreatedAt struct flag to omitempty, so that there is no need to extend the Update method.


If this is intended behaviour please let me know and I would love to hear why.