### PR TITLE
Optimistic locking

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,7 @@
+package mgm
+
+import (
+	"errors"
+)
+
+var ErrVersionning = errors.New("versionning error")

--- a/field.go
+++ b/field.go
@@ -19,7 +19,7 @@ type DateFields struct {
 }
 
 type VersionField struct {
-	Version int `json:"_v" bson:"_v"`
+	Version_ int `json:"_v" bson:"_v"`
 }
 
 // PrepareID method prepares the ID value to be used for filtering
@@ -45,7 +45,7 @@ func (f *IDField) SetID(id interface{}) {
 
 // GetVersion returns the model version field
 func (f *VersionField) GetVersion() interface{} {
-	return f.Version
+	return f.Version_
 }
 
 // GetVersionFieldName returns the field name holding the version field (has to match the bson tag)
@@ -55,12 +55,12 @@ func (f *VersionField) GetVersionFieldName() string {
 
 // SetVersion returns the model version field
 func (f *VersionField) IncrementVersion() {
-	f.Version++
+	f.Version_++
 }
 
 // Determines whether the version field is in its zero value
 func (f *VersionField) IsVersionZero() bool {
-	return f.Version == 0
+	return f.Version_ == 0
 }
 
 //--------------------------------

--- a/field.go
+++ b/field.go
@@ -18,6 +18,10 @@ type DateFields struct {
 	UpdatedAt time.Time `json:"updated_at" bson:"updated_at"`
 }
 
+type VersionField struct {
+	Version int `json:"version" bson:"version"`
+}
+
 // PrepareID method prepares the ID value to be used for filtering
 // e.g convert hex-string ID value to bson.ObjectId
 func (f *IDField) PrepareID(id interface{}) (interface{}, error) {
@@ -39,6 +43,21 @@ func (f *IDField) SetID(id interface{}) {
 	f.ID = id.(primitive.ObjectID)
 }
 
+// GetVersion returns the model version field
+func (f *VersionField) GetVersion() interface{} {
+	return f.Version
+}
+
+// GetVersionFieldName returns the field name holding the version field (has to match the bson tag)
+func (f *VersionField) GetVersionFieldName() string {
+	return "version"
+}
+
+// SetVersion returns the model version field
+func (f *VersionField) IncrementVersion() {
+	f.Version++
+}
+
 //--------------------------------
 // DateField methods
 //--------------------------------
@@ -51,7 +70,7 @@ func (f *DateFields) Creating() error {
 	return nil
 }
 
-// Saving hook is used here to set the `updated_at` field 
+// Saving hook is used here to set the `updated_at` field
 // value when creating or updateing a model.
 // TODO: get context as param the next version(4).
 func (f *DateFields) Saving() error {

--- a/field.go
+++ b/field.go
@@ -19,7 +19,7 @@ type DateFields struct {
 }
 
 type VersionField struct {
-	Version int `json:"version" bson:"version"`
+	Version int `json:"_v" bson:"_v"`
 }
 
 // PrepareID method prepares the ID value to be used for filtering
@@ -50,12 +50,17 @@ func (f *VersionField) GetVersion() interface{} {
 
 // GetVersionFieldName returns the field name holding the version field (has to match the bson tag)
 func (f *VersionField) GetVersionFieldName() string {
-	return "version"
+	return "_v"
 }
 
 // SetVersion returns the model version field
 func (f *VersionField) IncrementVersion() {
 	f.Version++
+}
+
+// Determines whether the version field is in its zero value
+func (f *VersionField) IsVersionZero() bool {
+	return f.Version == 0
 }
 
 //--------------------------------

--- a/model.go
+++ b/model.go
@@ -27,8 +27,8 @@ type Model interface {
 }
 
 type Versionable interface {
-	GetVersion() interface{}
-	GetVersionFieldName() string
+	Version() interface{}
+	GetVersionBsonFieldName() string
 	IncrementVersion()
 	IsVersionZero() bool
 }

--- a/model.go
+++ b/model.go
@@ -26,10 +26,17 @@ type Model interface {
 	SetID(id interface{})
 }
 
+type Versionable interface {
+	GetVersion() interface{}
+	GetVersionFieldName() string
+	IncrementVersion()
+}
+
 // DefaultModel struct contains a model's default fields.
 type DefaultModel struct {
-	IDField    `bson:",inline"`
-	DateFields `bson:",inline"`
+	IDField      `bson:",inline"`
+	DateFields   `bson:",inline"`
+	VersionField `bson:",inline"`
 }
 
 // Creating function calls the inner fields' defined hooks

--- a/model.go
+++ b/model.go
@@ -30,13 +30,13 @@ type Versionable interface {
 	GetVersion() interface{}
 	GetVersionFieldName() string
 	IncrementVersion()
+	IsVersionZero() bool
 }
 
 // DefaultModel struct contains a model's default fields.
 type DefaultModel struct {
-	IDField      `bson:",inline"`
-	DateFields   `bson:",inline"`
-	VersionField `bson:",inline"`
+	IDField    `bson:",inline"`
+	DateFields `bson:",inline"`
 }
 
 // Creating function calls the inner fields' defined hooks

--- a/model_test.go
+++ b/model_test.go
@@ -1,10 +1,11 @@
 package mgm_test
 
 import (
+	"testing"
+
 	"github.com/kamva/mgm/v3/internal/util"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"testing"
 )
 
 func TestPrepareInvalidId(t *testing.T) {
@@ -22,4 +23,12 @@ func TestPrepareId(t *testing.T) {
 	id, _ := primitive.ObjectIDFromHex(hexId)
 	require.Equal(t, val.(primitive.ObjectID), id)
 	util.AssertErrIsNil(t, err)
+}
+
+func TestVersion(t *testing.T) {
+	d := &Doc{}
+	require.Equal(t, 0, d.GetVersion())
+	require.Equal(t, "version", d.GetVersionFieldName())
+	d.IncrementVersion()
+	require.Equal(t, 1, d.GetVersion())
 }

--- a/model_test.go
+++ b/model_test.go
@@ -28,7 +28,7 @@ func TestPrepareId(t *testing.T) {
 func TestVersion(t *testing.T) {
 	d := &Doc{}
 	require.Equal(t, 0, d.GetVersion())
-	require.Equal(t, "version", d.GetVersionFieldName())
+	require.Equal(t, "_v", d.GetVersionFieldName())
 	d.IncrementVersion()
 	require.Equal(t, 1, d.GetVersion())
 }

--- a/operation.go
+++ b/operation.go
@@ -46,12 +46,12 @@ func update(ctx context.Context, c *Collection, model Model, opts ...*options.Up
 
 	res, err := c.UpdateOne(ctx, query, bson.M{"$set": model}, opts...)
 
-	if isVersionable && res.MatchedCount == 0 {
-		return fmt.Errorf("versioning error : document %v %v with version %v could not be found", c.Name(), model.GetID(), modelVersionable.GetVersion())
-	}
-
 	if err != nil {
 		return err
+	}
+
+	if isVersionable && res.MatchedCount == 0 {
+		return fmt.Errorf("versioning error : document %v %v with version %v could not be found", c.Name(), model.GetID(), modelVersionable.GetVersion())
 	}
 
 	return callToAfterUpdateHooks(ctx, res, model)

--- a/operation.go
+++ b/operation.go
@@ -2,6 +2,7 @@ package mgm
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kamva/mgm/v3/field"
 	"go.mongodb.org/mongo-driver/bson"
@@ -44,6 +45,10 @@ func update(ctx context.Context, c *Collection, model Model, opts ...*options.Up
 	}
 
 	res, err := c.UpdateOne(ctx, query, bson.M{"$set": model}, opts...)
+
+	if isVersionable && res.MatchedCount == 0 {
+		return fmt.Errorf("versioning error : document %v %v with version %v could not be found", c.Name(), model.GetID(), modelVersionable.GetVersion())
+	}
 
 	if err != nil {
 		return err

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -1,11 +1,12 @@
 package mgm_test
 
 import (
+	"testing"
+
 	"github.com/kamva/mgm/v3"
 	"github.com/kamva/mgm/v3/internal/util"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"testing"
 )
 
 func setupDefConnection() {
@@ -43,6 +44,7 @@ func findDoc(t *testing.T) *Doc {
 
 type Doc struct {
 	mgm.DefaultModel `bson:",inline"`
+	mgm.VersionField `bson:",inline"`
 
 	Name string `bson:"name"`
 	Age  int    `bson:"age"`


### PR DESCRIPTION
Hi,

I needed to have optimistic locking behavior on my project so implemented it in this pull request. It is based on a version field that gets incremented when saving. It can also be done through an updatedOn field but this PR uses the version technique for the DefaultModel.

It works the following way : 
A new field called "Version" has been added to DefaultModel (saves to "version" in the db)
Models have to implement a Versionable interface so that the behavior kicks in. DefaultModel implements it and so documents using the DefaultModel will have this enabled by default). This interface has 3 methods : 
GetVersion() -> returns the version number of this document
IncrementVersion() -> responsible for updating the version number
GetVersionFieldName() -> returns the name of the field that holds the version number

Then when the actual update is called, we can simply check that in the query part of the udpate that the version is the same as when the document was retrieved. If not, a custom error is raised.


